### PR TITLE
Fix version string

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,9 @@
 mkdir -p build
 cd build
 
+# Convert version to release tag format (e.g., 7.157.0 -> alpha_release-7-157-0)
+RELEASE_TAG="alpha_release-${PKG_VERSION//./-}"
+
 # Configure with CMake
 cmake -G "Unix Makefiles" \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
@@ -12,10 +15,11 @@ cmake -G "Unix Makefiles" \
   -DBUILD_SHARED_LIBS=ON \
   -DENABLE_JAVA=OFF \
   -DENABLE_MOTIF=OFF \
+  -DENABLE_DOXYGEN=OFF \
   -DREADLINE_DIR=${PREFIX} \
   -DLIBXML2_DIR=${PREFIX} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
-  -DRELEASE_TAG="alpha_release-{{ version | replace('.', '-') }}" \
+  -DRELEASE_TAG="${RELEASE_TAG}" \
   ..
 
 # Build and install C/C++ libraries

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,8 @@
 mkdir -p build
 cd build
 
-# Specify version separated by dots (not dashes!)
+# Convert version to release tag format (e.g., 7.157.0 -> alpha_release-7-157-0)
+RELEASE_TAG="alpha_release-${PKG_VERSION//./-}"
 
 # Configure with CMake
 cmake -G "Unix Makefiles" \
@@ -18,12 +19,21 @@ cmake -G "Unix Makefiles" \
   -DREADLINE_DIR=${PREFIX} \
   -DLIBXML2_DIR=${PREFIX} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
-  -DRELEASE_TAG="${PKG_VERSION}" \
+  -DRELEASE_TAG="${RELEASE_TAG}" \
   ..
 
 # Build and install C/C++ libraries
 make -j${CPU_COUNT}
 make install
+
+# Replace the broken _version.py with a correct one
+# CMake generates a malformed version, so we override it entirely
+cat > ../python/MDSplus/_version.py << EOF
+version = tuple(map(int, "${PKG_VERSION}".split('.')))
+__version__ = "${PKG_VERSION}"
+release_tag = "${PKG_VERSION}"
+release_date = "$(date -u '+%a %b %d %H:%M:%S UTC %Y')"
+EOF
 
 # Install Python package to proper site-packages location
 cd ../python/MDSplus

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,8 +5,8 @@
 mkdir -p build
 cd build
 
-# Convert version to release tag format (e.g., 7.157.0 -> alpha_release-7-157-0)
-RELEASE_TAG="alpha_release-${PKG_VERSION//./-}"
+# Specify version separated by dots (not dashes!)
+RELEASE_TAG="alpha_release-${PKG_VERSION}"
 
 # Configure with CMake
 cmake -G "Unix Makefiles" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,6 @@ mkdir -p build
 cd build
 
 # Specify version separated by dots (not dashes!)
-RELEASE_TAG="alpha_release-${PKG_VERSION}"
 
 # Configure with CMake
 cmake -G "Unix Makefiles" \
@@ -19,7 +18,7 @@ cmake -G "Unix Makefiles" \
   -DREADLINE_DIR=${PREFIX} \
   -DLIBXML2_DIR=${PREFIX} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
-  -DRELEASE_TAG="${RELEASE_TAG}" \
+  -DRELEASE_TAG="${PKG_VERSION}" \
   ..
 
 # Build and install C/C++ libraries

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,7 @@ cmake -G "Unix Makefiles" \
   -DREADLINE_DIR=${PREFIX} \
   -DLIBXML2_DIR=${PREFIX} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
+  -DRELEASE_TAG="alpha_release-{{ version | replace('.', '-') }}" \
   ..
 
 # Build and install C/C++ libraries

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   skip: true  # [osx]
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This fixes the `MDSplus.__version__` string to be correctly reflecting the MDSplus version. This was verified to work for MDSplus built with `build_locally.py`
<!--
Please add any other relevant info below:
-->
